### PR TITLE
Add sln file

### DIFF
--- a/elmish-getting-started.sln
+++ b/elmish-getting-started.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "App", "src\App.fsproj", "{93AE29C6-085A-444F-A143-89FA83EDCA8E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Debug|x64.Build.0 = Debug|Any CPU
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Debug|x86.Build.0 = Debug|Any CPU
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Release|x64.ActiveCfg = Release|Any CPU
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Release|x64.Build.0 = Release|Any CPU
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Release|x86.ActiveCfg = Release|Any CPU
+		{93AE29C6-085A-444F-A143-89FA83EDCA8E}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
### What
Add sln file to the project to make it easier to view all files in Rider in `File System` view. 

### Why
I opened this project in Rider because that's what I usually use for F#, but Rider could either open the project as a folder or as a project. When I chose folder view the F# files didn't get analyzed at all. When I chose project it showed only the `src` folder in `File System` view in the explorer, which isn't super nice. 